### PR TITLE
lowercase check names

### DIFF
--- a/dal/DALUser.js
+++ b/dal/DALUser.js
@@ -29,7 +29,7 @@ exports.daluser = {
     register: async (username, password) =>{
         userList = await findAll()
         for(let i = 0; i < userList.length; i++){
-            if (userList[i].username === username){
+            if (userList[i].username.toLowerCase() === username.toLowerCase()){
                 return null
             }
         }


### PR DESCRIPTION
makes sure that people can't have the same name when registering, even if one of the usernames is a different case